### PR TITLE
Fix publisher warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # kafka-topic-loader
+[ ![Download](https://api.bintray.com/packages/sky-uk/oss-maven/kafka-topic-loader/images/download.svg) ](https://bintray.com/sky-uk/oss-maven/kafka-topic-loader/_latestVersion)
+
 Reads the contents of provided Kafka topics, either the topics in their entirety or up until a consumer groups last committed Offset depending on which `LoadTopicStrategy` you provide.
 
 As of version `1.3.0`, data can be loaded either from complete topics using `load` or `loadAndRun`.
 
-Since version `1.3.3` the library is cross compiled for scala versions `2.12` and `2.13`.
+Since version `1.4.0` the library is cross compiled for scala versions `2.12` and `2.13`.
 
 Add the following to your `build.sbt`:
 ```scala
-libraryDependencies += "com.sky" %% "kafka-topic-loader" % "1.3.3"
+libraryDependencies += "com.sky" %% "kafka-topic-loader" % "<version>"
 
 resolvers += "bintray-sky-uk-oss-maven" at "https://dl.bintray.com/sky-uk/oss-maven"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ scalacOptions ++= Seq(
   "-Ywarn-unused:privates",
   "-Ywarn-value-discard"
 ) ++ {
-  if (scalaBinaryVersion.value == "2.13") Seq.empty else Seq("-Xfuture", "-Ypartial-unification", "-Yno-adapted-args")
+  if (scalaBinaryVersion.value == "2.13") Seq("-Wconf:msg=annotation:silent")
+  else Seq("-Xfuture", "-Ypartial-unification", "-Yno-adapted-args")
 }
 
 scalafmtVersion := "1.5.1"


### PR DESCRIPTION
Release following #44 failed because the `publish` step thought that the `nowarn` annotation was unused for scala 2.13 (even though everything compiled fine and all the tests passed). This just ignores the warning that would come with unused annotations.

Also, updating the readme version and adding a badge to the latest version published to bintray.