### PR TITLE
Release new versions to Sonatype

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,6 @@ The project is built and released for Scala versions 2.12 and 2.13. To compile a
 
 ## Performing a release (for project maintainers)
 
-1. Follow the [sbt-bintray publishing guidelines](https://github.com/sbt/sbt-bintray#publishing) to ensure you are authenticated with Bintray. Note that you need to be a member of the `sky-uk` Bintray organization.
-2. Run `sbt release` to perform the release of the binaries to Bintray.
-3. Check you are happy with the draft publication of the new version [here](https://bintray.com/sky-uk/oss-maven/kafka-topic-loader) and, if so, run `sbt bintrayRelease` to make the new version publicly accessible.
-
----
-
 ### Generate a GPG key
 
 1. Generate a GPG key:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,93 @@
 # Contributing
 
-Contributions are welcomed! 
+Contributions are welcomed!
 
-When contributing to this repository, please first discuss the change you wish to make via GitHub
-issue before making a change.  This saves everyone from wasted effort in the event that the proposed
-changes need some adjustment before they are ready for submission.
+When contributing to this repository, please first discuss the change you wish to make via GitHub issue before making a change. This saves everyone from wasted effort in the event that the proposed changes need some adjustment before they are ready for submission.
 
 ## Pull Request Process
 
 1. Fork the repo, push your commits to a branch of your fork, open the PR.
 2. Make sure you update the README.md where relevant.
-3. Project maintainers will squash-merge Pull Requests once they are happy.  There may be one or more
-   cycles of feedback on the PR before they are satisfied.
+3. Project maintainers will squash-merge Pull Requests once they are happy. There may be one or more cycles of feedback on the PR before they are satisfied.
 
 ## Build and run tests locally
 
 The software is written in [Scala](https://scala-lang.org/) and is built with [SBT](http://www.scala-sbt.org/).
 
-The project is built and released for Scala versions 2.12 and 2.13.
-To compile and test both versions run `sbt +test`.
+The project is built and released for Scala versions 2.12 and 2.13. To compile and test both versions run `sbt +test`.
 
 ## Performing a release (for project maintainers)
 
-1. Follow the [sbt-bintray publishing guidelines](https://github.com/sbt/sbt-bintray#publishing) to ensure you are
-   authenticated with Bintray.  Note that you need to be a member of the `sky-uk` Bintray organization. 
+1. Follow the [sbt-bintray publishing guidelines](https://github.com/sbt/sbt-bintray#publishing) to ensure you are authenticated with Bintray. Note that you need to be a member of the `sky-uk` Bintray organization.
 2. Run `sbt release` to perform the release of the binaries to Bintray.
-3. Check you are happy with the draft publication of the new version [here](https://bintray.com/sky-uk/oss-maven/kafka-topic-loader)
-   and, if so, run `sbt bintrayRelease` to make the new version publicly accessible.
+3. Check you are happy with the draft publication of the new version [here](https://bintray.com/sky-uk/oss-maven/kafka-topic-loader) and, if so, run `sbt bintrayRelease` to make the new version publicly accessible.
+
+---
+
+### Generate a GPG key
+
+1. Generate a GPG key:
+
+   ```bash
+   $ gpg --full-generate-key
+   ```
+
+2. Kind: `RSA and RSA`
+3. Key size: `4096`
+4. Expiry: `2y`
+5. Enter your name, email, comment and passphrase
+
+### Distribute your GPG key
+
+1. Get your public key:
+
+   ```bash
+   $ gpg --list-keys
+
+   pub   rsa4096 2021-11-30 [SC] [expires: 2023-11-30]
+      CA925CD6C9E8D064FF05B4728190C4130ABA0F98
+   ```
+
+2. Send your GPG key:
+
+   ```bash
+   $ gpg --keyserver keyserver.ubuntu.com --send-keys CA925CD6C9E8D064FF05B4728190C4130ABA0F98
+   ```
+
+### Signing the release
+
+1. Create a file at `~/.sbt/1.0/sonatype.sbt`
+
+   ```sbt
+   credentials += Credentials("Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        "(Sonatype user name)",
+        "(Sonatype password)")
+   ```
+
+### Releasing to Sonatype
+
+1. To release interactively, run `sbt release`. This will ask for the version to release, the next version, your PGP passphrase (for Sonatype)
 
 ## Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of fostering an open and 
-welcoming community, we pledge to respect all people who contribute through reporting issues, 
-posting feature requests, updating documentation, submitting pull requests or patches, and other 
-activities.
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, 
-regardless of level of experience, gender, gender identity and expression, sexual orientation, 
-disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
-* Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit
-  permission
-* Other unethical or unprofessional conduct.
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, 
-code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By 
-adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently 
-applying these principles to every aspect of managing this project. Project maintainers who do not 
-follow or enforce the Code of Conduct may be permanently removed from the project team.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is 
-representing the project or its community.
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an 
-issue or contacting one or more of the project maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), 
-version 1.2.0, available at 
-[http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The project is built and released for Scala versions 2.12 and 2.13. To compile a
 
 ### Releasing to Sonatype
 
-1. To release interactively, run `sbt release`. This will ask for the version to release, the next version, your PGP passphrase (for Sonatype)
+1. To release interactively, run `sbt release`. This will ask for the version to release, the next version, your GPG passphrase (for Sonatype)
 
 ## Contributor Code of Conduct
 

--- a/build.sbt
+++ b/build.sbt
@@ -64,8 +64,6 @@ libraryDependencies ++= Seq(
 )
 // @formatter:on
 
-//resolvers ++= Seq("segence" at "https://dl.bintray.com/segence/maven-oss-releases/")
-
 addCommandAlias("checkFmt", ";scalafmt::test; test:scalafmt::test; sbt:scalafmt::test")
 addCommandAlias("runFmt", ";scalafmt; test:scalafmt; sbt:scalafmt")
 addCommandAlias("ciBuild", ";checkFmt; clean; +test")

--- a/build.sbt
+++ b/build.sbt
@@ -31,14 +31,14 @@ ThisBuild / scalacOptions ++= Seq(
 }
 // format: on
 
+publishTo := sonatypePublishToBundle.value
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+
 scalafmtVersion := "1.5.1"
 scalafmtOnCompile := true
 
 Test / parallelExecution := false
 Test / fork := true
-
-releaseCrossBuild := true
-licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
 
 val AkkaVersion    = "2.6.16"
 val CatsVersion    = "2.6.1"
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
 )
 // @formatter:on
 
-resolvers ++= Seq("segence" at "https://dl.bintray.com/segence/maven-oss-releases/")
+//resolvers ++= Seq("segence" at "https://dl.bintray.com/segence/maven-oss-releases/")
 
 addCommandAlias("checkFmt", ";scalafmt::test; test:scalafmt::test; sbt:scalafmt::test")
 addCommandAlias("runFmt", ";scalafmt; test:scalafmt; sbt:scalafmt")

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "com.sky"
+organization := "uk.sky"
 scalaVersion := "2.13.7"
 name := "kafka-topic-loader"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.10")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.1.2")
 addSbtPlugin("com.lucidchart"    % "sbt-scalafmt" % "1.16")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,48 @@
+import ReleaseTransformations._
+
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "uk.sky"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// Open-source license of your choice
+licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
+
+homepage := Some(url("https://github.com/sky-uk/kafka-topic-loader"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/sky-uk/kafka-topic-loader"),
+    "scm:git@github.com:sky-uk/kafka-topic-loader.git"
+  )
+)
+developers := List(
+  Developer(id = "bcarter97",
+            name = "Ben Carter",
+            email = "ben.carter@sky.uk",
+            url = url("https://github.com/bcarter97"))
+)
+
+// Remove all additional repository other than Maven Central from POM
+ThisBuild / pomIncludeRepository := { _ =>
+  false
+}
+
+releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
+
+autoAPIMappings := true
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,3 +1,5 @@
+import xerial.sbt.Sonatype._
+
 import ReleaseTransformations._
 
 // Your profile name of the sonatype account. The default is the same with the organization value
@@ -9,19 +11,7 @@ publishMavenStyle := true
 // Open-source license of your choice
 licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause"))
 
-homepage := Some(url("https://github.com/sky-uk/kafka-topic-loader"))
-scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/sky-uk/kafka-topic-loader"),
-    "scm:git@github.com:sky-uk/kafka-topic-loader.git"
-  )
-)
-developers := List(
-  Developer(id = "bcarter97",
-            name = "Ben Carter",
-            email = "ben.carter@sky.uk",
-            url = url("https://github.com/bcarter97"))
-)
+sonatypeProjectHosting := Some(GitHubHosting("sky-uk", "kafka-topic-loader", "user@example.com"))
 
 // Remove all additional repository other than Maven Central from POM
 ThisBuild / pomIncludeRepository := { _ =>


### PR DESCRIPTION
## Description

- This PR adds the ability to release new versions to the Sonatype repository, using a combination of `sbt-release` and `sbt-sonatype`.

## Sources

- https://central.sonatype.org/publish/requirements/gpg/
- https://github.com/xerial/sbt-sonatype, specifically the usage with [sbt-release](https://github.com/xerial/sbt-sonatype#using-with-sbt-release-plugin)
- https://github.com/sky-uk/cqlmigrate/blob/master/RELEASING.md (gradle example)