### PR TITLE
Allow building off tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
 branches:
   only:
     - master
+    - ^v\d+\.\d+\.\d+$
 
 before_install:
   - git fetch --tags


### PR DESCRIPTION
## Description

As per https://github.com/travis-ci/travis-ci/issues/3897, we need to whitelist tags for travis to build them.

This regex has been adapted to accept our semver versioning scheme.