### PR TITLE
Escape branch matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 branches:
   only:
     - master
-    - ^v\d+\.\d+\.\d+$
+    - /^v\d+\.\d+\.\d+$/
 
 before_install:
   - git fetch --tags


### PR DESCRIPTION
## Description

Forgot to escape the regex as per https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches

This will match all tags in the format "v`x`.`x`.`x`"