### PR TITLE
Add project description

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val scmUrl                 = "https://github.com/sky-uk/kafka-topic-loader"
 
 name                   := "kafka-topic-loader"
 organization           := "uk.sky"
+description            := "Loads the state of Kafka topics to populate your application on startup"
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"
 homepage               := Some(url(scmUrl))

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val scmUrl                 = "https://github.com/sky-uk/kafka-topic-loader"
 
 name                   := "kafka-topic-loader"
 organization           := "uk.sky"
-description            := "Loads the state of Kafka topics to populate your application on startup"
+description            := "Reads the contents of provided Kafka topics"
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"
 homepage               := Some(url(scmUrl))


### PR DESCRIPTION
## Description

Our other OSS has a description set which makes it available in the Sonatype repository metadata.

Description was pulled from the GitHub description on the right sidebar.

![image](https://user-images.githubusercontent.com/28694181/149964403-d7cdc0b4-4fb2-47fb-a57b-b98f0ffd58bb.png)
