### PR TITLE
Lower ScalaSteward frequency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,9 @@
 # Reference conf file -> https://github.com/scala-steward-org/scala-steward/blob/master/docs/repo-specific-configuration.md
 
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+pullRequests.frequency = "1 day"
+
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 updates.limit = 2


### PR DESCRIPTION
## Description

We're using a bit too many credits on Travis, most of which are coming from Scala Steward updating PRs.

We've updated all our libraries so the number of pull requests being opened has decreased, but this should ensure the numbers stay down in the future.