### PR TITLE
Catch only non-fatal errors loading config

### DIFF
--- a/src/main/scala/com/sky/kafka/topicloader/config/config.scala
+++ b/src/main/scala/com/sky/kafka/topicloader/config/config.scala
@@ -11,14 +11,14 @@ package object config {
   type ValidationResult[A] = ValidatedNec[ConfigException, A]
 
   implicit class TryOps[A](t: Try[A]) {
-    def validate(path: String): ValidationResult[A] = t.toEither.validate(path)
-  }
-
-  implicit class EitherOps[A](e: Either[Throwable, A]) {
-    def validate(path: String): ValidationResult[A] = e.leftMap {
+    private[topicloader] def validate(path: String): ValidationResult[A] = t.toEither.leftMap {
       case ce: ConfigException => ce
       case NonFatal(e)         => new ConfigException.BadValue(path, e.getMessage)
-      case e: Throwable        => throw e
     }.toValidatedNec
+  }
+
+  implicit class EitherOps[A](e: Either[IllegalArgumentException, A]) {
+    private[topicloader] def validate(path: String): ValidationResult[A] =
+      e.leftMap(e => new ConfigException.BadValue(path, e.getMessage)).toValidatedNec
   }
 }

--- a/src/main/scala/com/sky/kafka/topicloader/config/config.scala
+++ b/src/main/scala/com/sky/kafka/topicloader/config/config.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import com.typesafe.config.ConfigException
 
 import scala.util.Try
+import scala.util.control.NonFatal
 
 package object config {
   type ValidationResult[A] = ValidatedNec[ConfigException, A]
@@ -16,7 +17,8 @@ package object config {
   implicit class EitherOps[A](e: Either[Throwable, A]) {
     def validate(path: String): ValidationResult[A] = e.leftMap {
       case ce: ConfigException => ce
-      case e: Throwable        => new ConfigException.BadValue(path, e.getMessage)
+      case e if NonFatal(e)    => new ConfigException.BadValue(path, e.getMessage)
+      case e: Throwable        => throw e
     }.toValidatedNec
   }
 }

--- a/src/main/scala/com/sky/kafka/topicloader/config/config.scala
+++ b/src/main/scala/com/sky/kafka/topicloader/config/config.scala
@@ -17,7 +17,7 @@ package object config {
   implicit class EitherOps[A](e: Either[Throwable, A]) {
     def validate(path: String): ValidationResult[A] = e.leftMap {
       case ce: ConfigException => ce
-      case e if NonFatal(e)    => new ConfigException.BadValue(path, e.getMessage)
+      case NonFatal(e)         => new ConfigException.BadValue(path, e.getMessage)
       case e: Throwable        => throw e
     }.toValidatedNec
   }

--- a/src/test/scala/integration/TopicLoaderIntSpec.scala
+++ b/src/test/scala/integration/TopicLoaderIntSpec.scala
@@ -291,7 +291,7 @@ class TopicLoaderIntSpec extends IntegrationSpecBase {
       config.topicLoader.bufferSize.value shouldBe 10
     }
 
-    "fail to load a valid config" in new TestContext {
+    "fail to load an invalid config" in new TestContext {
       override implicit lazy val system: ActorSystem = ActorSystem(
         "test-actor-system",
         ConfigFactory.parseString(


### PR DESCRIPTION
## Description

- Throw fatal error as suggested here: https://github.com/alexandru/scala-best-practices/blob/master/sections/2-language-rules.md#28-must-not-catch-throwable-when-catching-exceptions
- Fix config test name