### PR TITLE
Crossbuild for Scala3

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,10 +1,8 @@
 rules = [
-  RemoveUnused,
   NoAutoTupling,
   DisableSyntax,
   LeakingImplicitClassVal,
   NoValInForComprehension,
-  ProcedureSyntax
 ]
 
 OrganizeImports {

--- a/.scalafix3.conf
+++ b/.scalafix3.conf
@@ -2,7 +2,7 @@ rules = [
   NoAutoTupling,
   DisableSyntax,
   LeakingImplicitClassVal,
-  NoValInForComprehension,
+  NoValInForComprehension
 ]
 
 OrganizeImports {

--- a/.scalafix3.conf
+++ b/.scalafix3.conf
@@ -1,10 +1,8 @@
 rules = [
-  RemoveUnused,
   NoAutoTupling,
   DisableSyntax,
   LeakingImplicitClassVal,
   NoValInForComprehension,
-  ProcedureSyntax
 ]
 
 OrganizeImports {

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,6 +6,6 @@ maxColumn = 120
 newlines.sometimesBeforeColonInMethodReturnType = false
 project.git = true
 rewrite.rules = [SortImports, RedundantBraces, RedundantParens, PreferCurlyFors]
-runner.dialect = scala213
+runner.dialect = scala3
 spaces.beforeContextBoundColon = Always
 style = defaultWithAlign

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: scala
 
 scala:
-  - 2.13.7
+  - 3.1.1
 jdk:
   - openjdk12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
   - 3.1.1
 jdk:
-  - openjdk12
+  - openjdk17
 
 # Avoid triggering a duplicate build for PRs
 branches:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Dependencies.all
 
+lazy val scala3                 = "3.1.1"
 lazy val scala213               = "2.13.8"
 lazy val scala212               = "2.12.15"
 lazy val supportedScalaVersions = List(scala213, scala212)
@@ -21,7 +22,7 @@ developers             := List(
   )
 )
 
-scalaVersion       := scala213
+scalaVersion       := scala3
 crossScalaVersions := supportedScalaVersions
 semanticdbEnabled  := true
 semanticdbVersion  := scalafixSemanticdb.revision
@@ -43,6 +44,15 @@ Test / fork              := true
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 libraryDependencies ++= all
+
+excludeDependencies ++= {
+  if (scalaBinaryVersion.value == "3")
+    Seq(
+      "com.typesafe.scala-logging" % "scala-logging_2.13",
+      "org.scala-lang.modules"     % "scala-collection-compat_2.13"
+    )
+  else Seq.empty
+}
 
 addCommandAlias("checkFix", "scalafixAll --check OrganizeImports; scalafixAll --check")
 addCommandAlias("runFix", "scalafixAll OrganizeImports; scalafixAll")

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,14 @@ ThisBuild / scalacOptions ++= Seq("-explaintypes") ++ {
 
 ThisBuild / scalafixDependencies += Dependencies.Plugins.organizeImports
 
+/** Scala 3 doesn't support two rules yet - RemoveUnused and ProcedureSyntax. So we require a different scalafix config
+  * for Scala 3
+  *
+  * RemoveUnused relies on -warn-unused which isn't available in scala 3 yet -
+  * https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html
+  *
+  * ProcedureSyntax doesn't exist in Scala 3 - https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html
+  */
 scalafixConfig           := {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((3, _)) => Some((ThisBuild / baseDirectory).value / ".scalafix3.conf")

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,8 @@ tpolecatScalacOptions ++= Set(ScalacOptions.source3)
 
 ThisBuild / scalacOptions ++= Seq("-explaintypes") ++ {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 13)) => Seq("-Wconf:msg=annotation:silent")
-    case _             => Nil
+    case Some((3, _)) | Some((2, 13)) => Seq("-Wconf:msg=annotation:silent")
+    case _                            => Nil
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import Dependencies.all
-
 lazy val scala3                 = "3.1.1"
 lazy val scala213               = "2.13.8"
 lazy val scala212               = "2.12.15"
@@ -50,7 +48,7 @@ Test / fork              := true
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-libraryDependencies ++= all
+libraryDependencies ++= Dependencies.all
 
 excludeDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,13 @@ ThisBuild / scalacOptions ++= Seq("-explaintypes") ++ {
 
 ThisBuild / scalafixDependencies += Dependencies.Plugins.organizeImports
 
+scalafixConfig           := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _)) => Some((ThisBuild / baseDirectory).value / ".scalafix3.conf")
+    case _            => None
+  }
+}
+
 Test / parallelExecution := false
 Test / fork              := true
 
@@ -46,12 +53,10 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 libraryDependencies ++= all
 
 excludeDependencies ++= {
-  if (scalaBinaryVersion.value == "3")
-    Seq(
-      "com.typesafe.scala-logging" % "scala-logging_2.13",
-      "org.scala-lang.modules"     % "scala-collection-compat_2.13"
-    )
-  else Seq.empty
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _)) => Dependencies.scala3Exclusions
+    case _            => Seq.empty
+  }
 }
 
 addCommandAlias("checkFix", "scalafixAll --check OrganizeImports; scalafixAll --check")

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies.all
 lazy val scala3                 = "3.1.1"
 lazy val scala213               = "2.13.8"
 lazy val scala212               = "2.12.15"
-lazy val supportedScalaVersions = List(scala213, scala212)
+lazy val supportedScalaVersions = List(scala3, scala213, scala212)
 lazy val scmUrl                 = "https://github.com/sky-uk/kafka-topic-loader"
 
 name                   := "kafka-topic-loader"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val logbackClassic        = "ch.qos.logback"              % "logback-classic"         % "1.2.11" % Runtime
   val scalaCollectionCompat = "org.scala-lang.modules"     %% "scala-collection-compat" % "2.7.0"
 
-  val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % "3.1.0"  % Test
+  val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % "3.1.0"  % Test cross CrossVersion.for3Use2_13
   val scalaTest     = "org.scalatest"           %% "scalatest"      % "3.2.12" % Test
 
   val core = Akka.base ++ Cats.all ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,10 +8,10 @@ object Dependencies {
 
   object Akka {
     private val version = "2.6.19"
-    val stream          = "com.typesafe.akka" %% "akka-stream"         % version
-    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "2.1.1"
-    val streamTestkit   = "com.typesafe.akka" %% "akka-stream-testkit" % version % Test
-    val testkit         = "com.typesafe.akka" %% "akka-testkit"        % version % Test
+    val stream          = "com.typesafe.akka" %% "akka-stream"         % version cross CrossVersion.for3Use2_13
+    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "2.1.1" cross CrossVersion.for3Use2_13
+    val streamTestkit   = "com.typesafe.akka" %% "akka-stream-testkit" % version % Test cross CrossVersion.for3Use2_13
+    val testkit         = "com.typesafe.akka" %% "akka-testkit"        % version % Test cross CrossVersion.for3Use2_13
     val base            = Seq(stream, streamKafka)
     val test            = Seq(streamTestkit, testkit)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,11 @@ object Dependencies {
   val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % "3.1.0"  % Test cross CrossVersion.for3Use2_13
   val scalaTest     = "org.scalatest"           %% "scalatest"      % "3.2.12" % Test
 
+  val scala3Exclusions = Seq(
+    "com.typesafe.scala-logging" % "scala-logging_2.13",
+    "org.scala-lang.modules"     % "scala-collection-compat_2.13"
+  )
+
   val core = Akka.base ++ Cats.all ++ Seq(
     kafkaClients,
     scalaLogging,

--- a/src/test/scala/base/IntegrationSpecBase.scala
+++ b/src/test/scala/base/IntegrationSpecBase.scala
@@ -25,13 +25,13 @@ import scala.jdk.CollectionConverters._
 
 abstract class IntegrationSpecBase extends WordSpecBase with Eventually {
 
-  override implicit val patienceConfig = PatienceConfig(20.seconds, 200.millis)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(20.seconds, 200.millis)
 
-  implicit val timeout = Timeout(5.seconds)
+  implicit val timeout: Timeout = Timeout(5.seconds)
 
   trait TestContext extends AkkaSpecBase with EmbeddedKafka {
 
-    implicit lazy val kafkaConfig =
+    implicit lazy val kafkaConfig: EmbeddedKafkaConfig =
       EmbeddedKafkaConfig(kafkaPort = RandomPort(), zooKeeperPort = RandomPort(), Map("log.roll.ms" -> "10"))
 
     override implicit lazy val system: ActorSystem = ActorSystem(

--- a/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
+++ b/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
@@ -109,13 +109,13 @@ class DeprecatedMethodsIntSpec extends IntegrationSpecBase {
           .runWith(Sink.ignore)
           .futureValue shouldBe Done
 
-        store.getRecords.futureValue.map(_.partition) should contain only (partitionsToRead.toList: _*)
+        store.getRecords.futureValue.map(_.partition).toSet should contain theSameElementsAs partitionsToRead.toList
       }
     }
   }
 
   class RecordStore()(implicit system: ActorSystem) {
-    private val storeActor = system.actorOf(Props(classOf[Store], RecordStore.this))
+    private val storeActor = system.actorOf(Props(classOf[Store]))
 
     def storeRecord(rec: ConsumerRecord[String, String])(implicit timeout: Timeout): Future[Int] =
       (storeActor ? rec).mapTo[Int]

--- a/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
+++ b/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
@@ -115,7 +115,8 @@ class DeprecatedMethodsIntSpec extends IntegrationSpecBase {
   }
 
   class RecordStore()(implicit system: ActorSystem) {
-    private val storeActor = system.actorOf(Props(classOf[Store]))
+    private val storeActor = system.actorOf(Props(new Store))
+
 
     def storeRecord(rec: ConsumerRecord[String, String])(implicit timeout: Timeout): Future[Int] =
       (storeActor ? rec).mapTo[Int]

--- a/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
+++ b/src/test/scala/integration/DeprecatedMethodsIntSpec.scala
@@ -117,7 +117,6 @@ class DeprecatedMethodsIntSpec extends IntegrationSpecBase {
   class RecordStore()(implicit system: ActorSystem) {
     private val storeActor = system.actorOf(Props(new Store))
 
-
     def storeRecord(rec: ConsumerRecord[String, String])(implicit timeout: Timeout): Future[Int] =
       (storeActor ? rec).mapTo[Int]
 

--- a/src/test/scala/utils/RandomPort.scala
+++ b/src/test/scala/utils/RandomPort.scala
@@ -2,12 +2,11 @@ package utils
 
 import java.net.ServerSocket
 
+import scala.util.Using
+
 object RandomPort {
-  def apply(): Int = {
-    val socket = new ServerSocket(0)
+  def apply(): Int = Using.resource(new ServerSocket(0)) { socket =>
     socket.setReuseAddress(true)
-    val port   = socket.getLocalPort
-    socket.close()
-    port
+    socket.getLocalPort
   }
 }


### PR DESCRIPTION
## Description

Cross build for Scala 3.

A continuation of this stale branch: https://github.com/sky-uk/kafka-topic-loader/tree/scala-3

## Change notes

- A separate scalaFix config is required, as scalaFix doesn't support Scala3 for some rules yet (`RemoveUnused`, `ProcedureSyntax`). In order to still utilise these rules in the Scala 2.x versions, we have a separate config for scala 3 without these rules.
- Implicits require types