### PR TITLE
Update akka to 2.6.19

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   }
 
   object Akka {
-    private val version = "2.6.18"
+    private val version = "2.6.19"
     val stream          = "com.typesafe.akka" %% "akka-stream"         % version
-    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "2.1.1"
+    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "3.0.0"
     val streamTestkit   = "com.typesafe.akka" %% "akka-stream-testkit" % version % Test
     val testkit         = "com.typesafe.akka" %% "akka-testkit"        % version % Test
     val base            = Seq(stream, streamKafka)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   object Akka {
     private val version = "2.6.19"
     val stream          = "com.typesafe.akka" %% "akka-stream"         % version
-    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "3.0.0"
+    val streamKafka     = "com.typesafe.akka" %% "akka-stream-kafka"   % "2.1.1"
     val streamTestkit   = "com.typesafe.akka" %% "akka-stream-testkit" % version % Test
     val testkit         = "com.typesafe.akka" %% "akka-testkit"        % version % Test
     val base            = Seq(stream, streamKafka)


### PR DESCRIPTION
Making another branch as the previous clashed with ScalaSteward's naming convention and it kept reverting the commit:
- https://github.com/sky-uk/kafka-topic-loader/pull/109